### PR TITLE
fix: allow wrap of filter chip elements

### DIFF
--- a/src/custom/filter-chip/__snapshots__/filter-chip.test.tsx.snap
+++ b/src/custom/filter-chip/__snapshots__/filter-chip.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FilterChip > should render as expected 1`] = `
 <div
-  class="inline-flex items-center px-3 py-1.5 gap-1.5 rounded-2xl border border-border"
+  class="inline-flex items-center px-3 py-1.5 gap-1.5 rounded-2xl border border-border flex-wrap"
 >
   <div
     class="text-foreground text-xs font-normal"

--- a/src/custom/filter-chip/filter-chip.tsx
+++ b/src/custom/filter-chip/filter-chip.tsx
@@ -26,7 +26,7 @@ const FilterChip = ({
   return (
     <div
       className={cn(
-        "inline-flex items-center px-3 py-1.5 gap-1.5 rounded-2xl border border-border",
+        "inline-flex items-center px-3 py-1.5 gap-1.5 rounded-2xl border border-border flex-wrap",
         className,
       )}
       {...props}


### PR DESCRIPTION
# In this PR

- Quick 1-liner fix to allow filter chip elements to wrap. This is needed for small viewports.

PR helper:
<img width="313" height="108" alt="image" src="https://github.com/user-attachments/assets/a1ac031a-85e0-497a-9a24-e49c57578795" />
