### PR TITLE
fix: Ensure text color for toast description is set correctly.

### DIFF
--- a/src/shadcn/ui/sonner.tsx
+++ b/src/shadcn/ui/sonner.tsx
@@ -13,7 +13,7 @@ const SonnerToast = ({ ...props }: ToasterProps) => {
           toast:
             "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
           content: "w-[calc(100%-1.2rem)]",
-          description: "group-[.toast]:text-muted-foreground max-h-[40vh] overflow-y-auto",
+          description: "group-[.toast]:data-[description]:text-muted-foreground max-h-[40vh] overflow-y-auto",
           actionButton:
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
           cancelButton:


### PR DESCRIPTION
The selector needed to be more specific for the color to be correctly set. This does slightly change the color of the light mode toast desription too as it wasn't being set properly before.
Contrast ratio for AA compliance is 4.5 and AAA compliance is 7.0

Before Light:
Contrast ratio 10.53
<img width="457" height="501" alt="Screenshot 2026-08-12 at 10 22 35" src="https://github.com/user-attachments/assets/69c86359-d566-4cc6-b865-d77a36db29df" />


After Light:
Contrast ratio 5.2
<img width="457" height="501" alt="Screenshot 2026-08-12 at 10 22 25" src="https://github.com/user-attachments/assets/6e20f722-33ea-4cc5-b7a1-cfefc45d22e0" />


Before Dark:
Contrast ratio 1.77
<img width="457" height="501" alt="Screenshot 2026-08-12 at 10 13 04" src="https://github.com/user-attachments/assets/598e958b-6de9-4b96-b8b7-28ad01dba5b2" />


After Dark:
Contrast ratio 7.29
<img width="457" height="501" alt="Screenshot 2026-08-12 at 10 12 47" src="https://github.com/user-attachments/assets/c0493e2d-11eb-40d9-b129-7fcd147b5fda" />
