### PR TITLE
fix: Disabled states for command item and multi select

### DIFF
--- a/src/custom/multi-select/multi-select-list-item.tsx
+++ b/src/custom/multi-select/multi-select-list-item.tsx
@@ -12,7 +12,7 @@ export const MultiSelectListItem = ({
   renderItem,
 }: MultiSelectListItemProps) => {
   const itemContent = (
-    <div className={cn("flex items-start gap-2 w-full", isDisabled && "opacity-50 cursor-not-allowed")}>
+    <div className={cn("flex items-start gap-2 w-full", isDisabled && "cursor-not-allowed")}>
       <Checkbox
         checked={isSelected}
         disabled={isDisabled}

--- a/src/custom/multi-select/multi-select.stories.tsx
+++ b/src/custom/multi-select/multi-select.stories.tsx
@@ -162,7 +162,7 @@ export const FormIntegration: Story = {
     disabledTooltip: "Item disabled for reason",
   },
 
-  render: () => {
+  render: ({ disabledTooltip }) => {
     const [projectName, setProjectName] = useState("")
     const [selectedUsers, setSelectedUsers] = useState<MultiSelectItem[]>([])
     const [userError, setUserError] = useState<string | undefined>()
@@ -201,6 +201,7 @@ export const FormIntegration: Story = {
           label="Assignees"
           labelIcon={Users}
           labelTooltip="Select team members to assign"
+          disabledTooltip={disabledTooltip}
           errorMessage={userError}
           placeholder="Select users..."
           onChange={(users) => {

--- a/src/shadcn/ui/command.tsx
+++ b/src/shadcn/ui/command.tsx
@@ -114,7 +114,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:text-muted-foreground/50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       className
     )}
     {...props}


### PR DESCRIPTION
Before, disabled items would have no pointer events and therefore wouldn't be able to trigger the disabled tooltip. If you removed the `pointer-events-none` the tooltip would then have 50% opacity:

https://github.com/user-attachments/assets/9cac250a-6174-48e0-8d4f-a4d3e46ce88f

After, now has pointer events to allow the tooltip to be seen and a color of `text-muted-foreground/50` to imply the disabled state without affecting the opacity of the tooltip. The menu item is still not able to be selected in this sate:

https://github.com/user-attachments/assets/0b828a39-2096-4a93-8eb5-b94d1bdc80e5

Also command palette disabled state:
<img width="248" height="329" alt="Screenshot 2026-08-21 at 14 16 38" src="https://github.com/user-attachments/assets/d7eb8083-6aab-457b-a731-552697e0e7f1" />
